### PR TITLE
14 server verify login authentication incorrect

### DIFF
--- a/app/ipcSocket/client/CMakeLists.txt
+++ b/app/ipcSocket/client/CMakeLists.txt
@@ -15,6 +15,10 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ../lib/include
 )
 
+# Handling user libraries
+# Set the option to indicate that using cross-compiled
+option(OPENSSL_CROSS_COMPILE "Indicate cross-compiled to user libraries builder" OFF)
+
 # Build user libraries
 add_subdirectory(../lib ${CMAKE_BINARY_DIR}/libBuild)
 

--- a/app/ipcSocket/lib/CMakeLists.txt
+++ b/app/ipcSocket/lib/CMakeLists.txt
@@ -18,9 +18,19 @@ foreach(LIBRARY ${LIBRARIES})
     add_library(${LIBRARY} SHARED ${SRC_FILES})
     target_include_directories(${LIBRARY} PUBLIC "include")
 
-    # If the library is encodeHandler, add the OpenSSL include directory
     if(${LIBRARY} STREQUAL "encodeHandler")
-        target_include_directories(${LIBRARY} PUBLIC ${OPENSSL_INCLUDE_PATH})
+        if(OPENSSL_CROSS_COMPILE)
+            # Set the path to the cross-compiled OpenSSL libraries and headers
+            set(OPENSSL_ROOT_DIR ${CMAKE_SOURCE_DIR}/../../../../crossBuildLib/openSSL_BBB)
+            # Tell CMake where to find the OpenSSL package
+            list(APPEND CMAKE_PREFIX_PATH ${OPENSSL_ROOT_DIR})
+            # Set include path for crossbuild openssl
+            set(OPENSSL_INCLUDE_PATH "${OPENSSL_ROOT_DIR}/include")
+            target_include_directories(${LIBRARY} PUBLIC ${OPENSSL_INCLUDE_PATH})
+        endif()
+        # Link do OpenSSL
+        find_package(OpenSSL REQUIRED)
+        target_link_libraries(${LIBRARY} OpenSSL::SSL OpenSSL::Crypto)
     endif()
 
     set_target_properties(${LIBRARY} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/libBuild")

--- a/app/ipcSocket/lib/include/encodeHandler.h
+++ b/app/ipcSocket/lib/include/encodeHandler.h
@@ -5,5 +5,6 @@
 #include <stdbool.h>
 
 bool encodePsw(const char *password, unsigned char *hash);
+unsigned int getHashSize();
 
 #endif

--- a/app/ipcSocket/lib/src/encodeHandler.c
+++ b/app/ipcSocket/lib/src/encodeHandler.c
@@ -31,3 +31,8 @@ bool encodePsw(const char *password, unsigned char *hash)
     EVP_MD_CTX_free(mdctx);
     return true;
 }
+
+unsigned int getHashSize()
+{
+    return EVP_MD_size(EVP_sha256());
+}

--- a/app/ipcSocket/lib/src/fileHandler.c
+++ b/app/ipcSocket/lib/src/fileHandler.c
@@ -11,7 +11,7 @@ bool readNextLine(FILE* pFile, char** pBuff) {
     // Remove trailing newline character
     size_t lineLen = strlen(*pBuff);
     if (lineLen > 0 && (*pBuff)[lineLen - 1] == '\n') {
-        pBuff[lineLen - 1] = '\0';
+        (*pBuff)[lineLen - 1] = '\0';
     }
 
     return true;

--- a/app/ipcSocket/server/CMakeLists.txt
+++ b/app/ipcSocket/server/CMakeLists.txt
@@ -15,28 +15,15 @@ set(SRC_FILES
 # Add executable
 add_executable(${PROJECT_NAME} ${SRC_FILES})
 
-# Set the path to the cross-compiled OpenSSL libraries and headers
-set(OPENSSL_ROOT_DIR ${CMAKE_SOURCE_DIR}/../../../../crossBuildLib/openSSL_BBB)
-
 # Set include directories
 target_include_directories(${PROJECT_NAME} PRIVATE
     include
     ../lib/include
 )
 
-# Link with OpenSSL
-# Tell CMake where to find the OpenSSL package
-list(APPEND CMAKE_PREFIX_PATH ${OPENSSL_ROOT_DIR})
-
-# Find the OpenSSL package
-find_package(OpenSSL REQUIRED)
-
-# Link your application with OpenSSL
-target_link_libraries(${PROJECT_NAME} OpenSSL::SSL OpenSSL::Crypto)
-
 # Handling user libraries
-# Override the OpenSSL include path for the encodeHandler library
-set(OPENSSL_INCLUDE_PATH "${OPENSSL_ROOT_DIR}/include")
+# Set the option to indicate that using cross-compiled
+option(OPENSSL_CROSS_COMPILE "Indicate cross-compiled to user libraries builder" ON)
 
 # Build user libraries
 add_subdirectory(../lib ${CMAKE_BINARY_DIR}/libBuild)

--- a/app/ipcSocket/server/src/verifyLoginHandler.c
+++ b/app/ipcSocket/server/src/verifyLoginHandler.c
@@ -19,13 +19,20 @@ bool verifyPassword(char* pcUserName, char* pcPass)
 
     // find the password on user name
     char* pStoredPass = findPswOnUser(pcUserName);
-    
     // Hash and compare the received password
-    unsigned char hash[EVP_MAX_MD_SIZE];
+    int iHashSize = getHashSize();
+    unsigned char hash[iHashSize];
     if(pStoredPass) {
         if(encodePsw(pcPass, hash))
-        {
-            bRet = (memcmp(hash, pStoredPass, EVP_MAX_MD_SIZE) == 0);
+        {   
+            // format the hash to binary string
+            char binHash[iHashSize * 2 + 1];
+            memset(binHash, 0, sizeof(binHash));
+            for (unsigned int i = 0; i < iHashSize; i++) 
+            {
+                sprintf(binHash + strlen(binHash), "%02x", hash[i]);
+            }
+            bRet = (strcmp(pStoredPass,binHash) == 0);
         }
         free(pStoredPass);
     }
@@ -55,10 +62,10 @@ char* findPswOnUser(char* pcUsername)
                 if(strcmp(pUser, pcUsername) == 0)
                 {
                     pPsw = parseCSVToken(pLine, DBDelim, PSW_POS);
-                    free((void*)pUser); // Cast to void* before freeing
+                    free((void*)pUser); 
                     break;
                 }
-                free((void*)pUser); // Cast to void* before freeing
+                free((void*)pUser);
             }
             free(pLine);
             pLine = NULL;
@@ -68,5 +75,5 @@ char* findPswOnUser(char* pcUsername)
     free(pLine);
     fclose(pFp);
 
-    return (char*)pPsw; // Cast to char* to match the return type
+    return (char*)pPsw;
 }

--- a/app/ipcSocket/tool/CMakeLists.txt
+++ b/app/ipcSocket/tool/CMakeLists.txt
@@ -7,9 +7,6 @@ set(SRC_FILES
     src/userDBHandler.c
 )
 
-# Build user libraries
-add_subdirectory(../lib ${CMAKE_BINARY_DIR}/libBuild)
-
 # Add executable
 add_executable(${PROJECT_NAME} ${SRC_FILES})
 
@@ -19,9 +16,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ../lib/include
 )
 
-# Link with OpenSSL
-find_package(OpenSSL REQUIRED)
-target_link_libraries(${PROJECT_NAME} OpenSSL::SSL OpenSSL::Crypto)
+# Handling user libraries
+# Set the option to indicate that using cross-compiled
+option(OPENSSL_CROSS_COMPILE "Indicate cross-compiled to user libraries builder" OFF)
+
+# Build user libraries
+add_subdirectory(../lib ${CMAKE_BINARY_DIR}/libBuild)
 
 # Link with user libraries
 target_link_libraries(${PROJECT_NAME} 

--- a/app/ipcSocket/tool/src/userDBHandler.c
+++ b/app/ipcSocket/tool/src/userDBHandler.c
@@ -26,18 +26,22 @@ void updateDB(const char* pcDBFile)
         {
             case 'a':
             {
+                // Request user and psw from user
                 char user[MAX_USER_SIZE];
                 char passwd[MAX_PASSWORD_SIZE];
                 printf("user: ");
                 scanf(" %s", user);
                 printf("password: ");
                 scanf(" %s", passwd);
-                unsigned char hash[EVP_MAX_MD_SIZE];
+
+                int iHashSize = getHashSize();
+                unsigned char hash[iHashSize];
                 if(encodePsw(passwd, hash))
                 {
-                    char newLineDB[MAX_USER_SIZE + EVP_MAX_MD_SIZE * 2 + 1];
+                    char newLineDB[MAX_USER_SIZE + iHashSize * 2 + 1 + 1]; // +1 for ',' and +1 for null terminator
+                    memset(newLineDB, 0, sizeof(newLineDB)); 
                     sprintf(newLineDB, "%s,", user);
-                    for (unsigned int i = 0; i < EVP_MD_size(EVP_sha256()); i++) 
+                    for (unsigned int i = 0; i < iHashSize; i++) 
                     {
                         sprintf(newLineDB + strlen(newLineDB), "%02x", hash[i]);
                     }


### PR DESCRIPTION
root cause: The newline character in database lead to the different when compare password. 
Fix: remove newline character when parse password from database before comparing 